### PR TITLE
Fix ChatRoom user fetch effect

### DIFF
--- a/src/components/ChatRoom.js
+++ b/src/components/ChatRoom.js
@@ -46,7 +46,7 @@ export default function ChatRoom({ roomId }) {
     if (!dontGoDown) {
           scrollToBottom();
         }
-  }, [messages]);
+  }, []);
 
   useEffect(() => {
     // on mobile browsers, visualViewport.height shrinks when the keyboard opens


### PR DESCRIPTION
## Summary
- run `supabase.auth.getUser()` only once

## Testing
- `npm run lint` *(fails: `next` not found)*